### PR TITLE
Report successful plugin load

### DIFF
--- a/src/main/kotlin/burp/BurpExtender.kt
+++ b/src/main/kotlin/burp/BurpExtender.kt
@@ -18,6 +18,7 @@
 
 package burp
 
+import java.io.PrintWriter
 import java.net.URL
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
@@ -59,6 +60,10 @@ class BurpExtender : IBurpExtender, IScannerCheck, IExtensionStateListener {
         callbacks.setExtensionName(NAME)
         callbacks.registerScannerCheck(this)
         callbacks.registerExtensionStateListener(this)
+
+        val stdout = PrintWriter(callbacks.getStdout(), true)
+        stdout.println("log4shell scanner loaded")
+        stdout.close()
     }
 
     override fun doPassiveScan(baseRequestResponse: IHttpRequestResponse?): MutableList<IScanIssue> =


### PR DESCRIPTION
Unfortunately Burp Suite API doesn't provide any facilities to check plugin states in runtime. All plugins are loaded in background, so when Burp Suite is up and running is not the same as all plugins are ready. The only way to automate these things is to monitor standard output/error of the plugin, but it doesn't report anything useful after being loaded.